### PR TITLE
Filter the steering input to prevent instantaneous changes in steering angle

### DIFF
--- a/include/hl/LowPassFilter.hpp
+++ b/include/hl/LowPassFilter.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <SFML/System/Time.hpp>
+
+#include <cmath>
+
+template <typename T>
+class LowPassFilter {
+public:
+    LowPassFilter(sf::Time dt, float cutoff_frequency, T initial_value)
+        : m_dt(dt)
+        , m_cutoff_frequency(cutoff_frequency)
+        , m_previous(initial_value)
+    {
+    }
+
+    void update(T input)
+    {
+        const auto a = std::exp(-m_cutoff_frequency * m_dt.asSeconds());
+        m_previous = m_previous * a + input * (1 - a);
+    }
+
+    [[nodiscard]] T value() const { return m_previous; }
+
+private:
+    sf::Time m_dt;
+    float m_cutoff_frequency;
+    T m_previous;
+};

--- a/include/hl/Vehicle.hpp
+++ b/include/hl/Vehicle.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <hl/LowPassFilter.hpp>
+
 #include <SFML/Graphics.hpp>
 
 class Vehicle : public sf::Drawable, private sf::Transformable {
@@ -17,10 +19,10 @@ public:
 private:
     void step(float throttle, float brake, const sf::Angle& steering);
 
-    const sf::Time m_timestep;
+    const sf::Time m_timestep { sf::seconds(1.f / 100.f) };
     sf::Time m_time_budget {};
 
-    sf::Angle m_steering {};
+    LowPassFilter<sf::Angle> m_steering { m_timestep, 10.f, sf::degrees(0) };
     sf::Vector2f m_velocity {};
     sf::Angle m_yaw_rate {};
 };

--- a/src/Vehicle.cpp
+++ b/src/Vehicle.cpp
@@ -66,32 +66,35 @@ void Vehicle::draw(sf::RenderTarget& target, const sf::RenderStates& /*states*/)
     rectangle.setRotation(getRotation());
     rectangle.setFillColor(sf::Color::Yellow);
     target.draw(rectangle);
+    const auto transform = rectangle.getTransform();
 
     auto half_size = rectangle.getSize() / 2.f;
 
     auto fl_wheel = sf::RectangleShape(half_size / 2.f);
     fl_wheel.setOrigin(fl_wheel.getSize() / 2.f);
-    fl_wheel.setPosition(getPosition() + sf::Vector2f(half_size.x, -half_size.y));
-    fl_wheel.setRotation(m_steering.value());
+    fl_wheel.setPosition(transform.transformPoint(sf::Vector2f(half_size.x, -half_size.y) + rectangle.getOrigin()));
+    fl_wheel.setRotation(getRotation() + m_steering.value());
     fl_wheel.setFillColor(sf::Color::Black);
     target.draw(fl_wheel);
 
     auto fr_wheel = sf::RectangleShape(half_size / 2.f);
     fr_wheel.setOrigin(fr_wheel.getSize() / 2.f);
-    fr_wheel.setPosition(getPosition() + sf::Vector2f(half_size.x, half_size.y));
-    fr_wheel.setRotation(m_steering.value());
+    fr_wheel.setPosition(transform.transformPoint(sf::Vector2f(half_size.x, half_size.y) + rectangle.getOrigin()));
+    fr_wheel.setRotation(getRotation() + m_steering.value());
     fr_wheel.setFillColor(sf::Color::Black);
     target.draw(fr_wheel);
 
     auto bl_wheel = sf::RectangleShape(half_size / 2.f);
     bl_wheel.setOrigin(bl_wheel.getSize() / 2.f);
-    bl_wheel.setPosition(getPosition() + sf::Vector2f(-half_size.x, -half_size.y));
+    bl_wheel.setPosition(transform.transformPoint(sf::Vector2f(-half_size.x, -half_size.y) + rectangle.getOrigin()));
+    bl_wheel.setRotation(getRotation());
     bl_wheel.setFillColor(sf::Color::Black);
     target.draw(bl_wheel);
 
     auto rr_wheel = sf::RectangleShape(half_size / 2.f);
     rr_wheel.setOrigin(rr_wheel.getSize() / 2.f);
-    rr_wheel.setPosition(getPosition() + sf::Vector2f(-half_size.x, half_size.y));
+    rr_wheel.setPosition(transform.transformPoint(sf::Vector2f(-half_size.x, half_size.y) + rectangle.getOrigin()));
+    rr_wheel.setRotation(getRotation());
     rr_wheel.setFillColor(sf::Color::Black);
     target.draw(rr_wheel);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,3 +1,7 @@
 add_executable(test-vehicle Vehicle.cpp)
 target_link_libraries(test-vehicle PRIVATE hotlappers-core Catch2::Catch2WithMain)
 add_test(NAME test-vehicle COMMAND test-vehicle)
+
+add_executable(test-lowpassfilter LowPassFilter.cpp)
+target_link_libraries(test-lowpassfilter PRIVATE hotlappers-core Catch2::Catch2WithMain)
+add_test(NAME test-lowpassfilter COMMAND test-lowpassfilter)

--- a/tests/LowPassFilter.cpp
+++ b/tests/LowPassFilter.cpp
@@ -1,0 +1,19 @@
+#include <hl/LowPassFilter.hpp>
+
+#include <catch2/catch_all.hpp>
+
+TEST_CASE("LowPassFilter class")
+{
+    const auto cutoff_frequency = 1.f;
+    const auto initial_value = 0.f;
+    LowPassFilter lpf(sf::seconds(0.1f), cutoff_frequency, initial_value);
+    CHECK(lpf.value() == initial_value);
+    auto previous = initial_value;
+    for (size_t i = 0; i < 100; ++i) {
+        lpf.update(1.f);
+        CHECK(lpf.value() > 0.f);
+        CHECK(lpf.value() < 1.f);
+        CHECK(lpf.value() > previous);
+        previous = lpf.value();
+    }
+}


### PR DESCRIPTION
Because we're using a low pass filter, the dynamics are well behaved and tunable. If we want the steering to feel snappier or slower in response to keyboard inputs, that can easily be changed by adjusted the cutoff frequency of the filter. I'm pretty happy with this API. Because it stores the last value it calculated, the filter totally replaces the previous value stored in `Vehicle` and can be access with `.value()` just like if you're using something like `std::optional`.