### PR TITLE
Catch2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ include(cmake/CPM.cmake)
 add_subdirectory(external)
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "(GNU|Clang)")
-    add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wsign-conversion)
+    add_compile_options(-Werror -Wall -Wextra -Wpedantic -Wshadow -Wconversion -Wsign-conversion)
 elseif(CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
     add_compile_options(/WX /W4 /permissive-)
 endif()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -8,4 +8,4 @@ CPMAddPackage(GITHUB_REPOSITORY eliasdaler/imgui-sfml
               GIT_TAG 29dbc25b5a4f3e7bde4a07472395071457a7d2ee
               OPTIONS "IMGUI_DIR ${imgui_SOURCE_DIR}" "IMGUI_SFML_FIND_SFML OFF")
 
-CPMAddPackage("gh:catchorg/Catch2@3.0.1")
+CPMAddPackage("gh:catchorg/Catch2#372b7575f67ae82cd925452f6b8dcbd4ad8ea071")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -1,6 +1,6 @@
 set(CPM_DONT_UPDATE_MODULE_PATH ON)
 
-CPMAddPackage("gh:SFML/SFML#0785093ebc50de5df30043082611cb2430584cf0")
+CPMAddPackage("gh:SFML/SFML#27a77747868b0097b63f77fa224ea047ca11ecbb")
 
 CPMAddPackage("gh:ocornut/imgui@1.87")
 


### PR DESCRIPTION
Catch2 trunk fixes a compiler warning that caused us to remove `-Wconversion`. I upgraded Catch2 to the latest commit and did the same with SFML just for good measure. 